### PR TITLE
Feature/added scrolling

### DIFF
--- a/components/frames/items_frame.py
+++ b/components/frames/items_frame.py
@@ -1,10 +1,8 @@
 import customtkinter as ctk
-from backend.models import LoginItemModel, NoteItemModel
 from components.frames.items_frames.all_items_frame import AllItemsFrame
 from components.frames.items_frames.bin_items_frame import BinItemsFrame
 from components.frames.items_frames.logins_frame import LoginItemsFrame
 from components.frames.items_frames.notes_frame import NoteItemsFrame
-from components.frames.items_frames.search_results_frame import SearchResultsFrame
 
 
 class ItemsFrame(ctk.CTkScrollableFrame):
@@ -23,10 +21,17 @@ class ItemsFrame(ctk.CTkScrollableFrame):
         )
         self.current_frame.grid(row=0, column=0, sticky="nsew", padx=6, pady=6)
 
-    def __switch_frame(self, frame: ctk.CTkFrame, **kwargs):
+        # Get internal canvas (needed for smooth scrolling)
+        self.canvas = self._parent_canvas
+
+        # Enable mouse wheel scrolling
+        self.bind("<Enter>", self._bind_scroll_events)  # Activate scrolling when mouse enters
+        self.bind("<Leave>", self._unbind_scroll_events)  # Deactivate scrolling when mouse leaves
+
+    def __switch_frame(self, frame: ctk.CTkFrame):
         self.current_frame.destroy()
         self.current_frame = frame(
-            self, fg_color="transparent", controllers=self.controllers, **kwargs
+            self, fg_color="transparent", controllers=self.controllers
         )
         self.current_frame.grid(row=0, column=0, sticky="nsew", padx=6, pady=6)
 
@@ -43,6 +48,18 @@ class ItemsFrame(ctk.CTkScrollableFrame):
     def show_secure_notes(self):
         self.__switch_frame(NoteItemsFrame)
 
-    def show_search_results(self, results: list[LoginItemModel | NoteItemModel]):
-        self.__switch_frame(SearchResultsFrame, search_results=results)
+    def _bind_scroll_events(self, event=None):
+        """Bind scrolling events when the mouse is over the frame."""
+        self.canvas.bind_all("<MouseWheel>", self._on_scroll)  # Windows/macOS
+        self.canvas.bind_all("<Button-4>", lambda e: self.canvas.yview_scroll(-1, "units"))  # Linux Scroll Up
+        self.canvas.bind_all("<Button-5>", lambda e: self.canvas.yview_scroll(1, "units"))   # Linux Scroll Down
 
+    def _unbind_scroll_events(self, event=None):
+        """Unbind scrolling events when the mouse leaves the frame."""
+        self.canvas.unbind_all("<MouseWheel>")
+        self.canvas.unbind_all("<Button-4>")
+        self.canvas.unbind_all("<Button-5>")
+
+    def _on_scroll(self, event):
+        """Handle mouse scroll event."""
+        self.canvas.yview_scroll(-1 * (event.delta // 120), "units")

--- a/components/frames/items_frame.py
+++ b/components/frames/items_frame.py
@@ -45,3 +45,4 @@ class ItemsFrame(ctk.CTkScrollableFrame):
 
     def show_search_results(self, results: list[LoginItemModel | NoteItemModel]):
         self.__switch_frame(SearchResultsFrame, search_results=results)
+


### PR DESCRIPTION
# Pretty self explanatory

- it now allows to scroll naturally unlike default customtkinter applications

## Technical Details
1. Used self._parent_canvas instead of self.winfo_toplevel()
        CTkScrollableFrame uses an internal canvas for scrolling.
        Binding scroll events directly to this canvas ensures they are handled correctly.

2. Bound scroll events only when the mouse is inside the frame (<Enter> and <Leave>)
        Prevents accidental scrolling when the mouse is outside the frame.
        Keeps the UI clean and avoids interfering with other widgets.

 3. Used bind_all() for <MouseWheel>, <Button-4>, and <Button-5>
        Windows/macOS: <MouseWheel> (handles vertical scrolling).
        Linux: <Button-4> (scroll up) & <Button-5> (scroll down).
        Ensures smooth scrolling across all operating systems.

4. Corrected the scroll direction calculation
        Used `event.delta // 120` for consistent scroll speed on Windows.